### PR TITLE
Small Fixes and Implementations to Today and Tomorrow

### DIFF
--- a/app/src/main/java/co/develhope/meteoapp/MainActivity.kt
+++ b/app/src/main/java/co/develhope/meteoapp/MainActivity.kt
@@ -6,8 +6,10 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.navigation.findNavController
 import androidx.navigation.ui.onNavDestinationSelected
 import androidx.navigation.ui.setupWithNavController
+import co.develhope.meteoapp.data.Data
 import co.develhope.meteoapp.databinding.ActivityMainBinding
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import org.threeten.bp.OffsetDateTime
 
 class MainActivity : AppCompatActivity() {
 
@@ -51,6 +53,17 @@ class MainActivity : AppCompatActivity() {
                         it.onNavDestinationSelected(navController)
                     }
 
+                    true
+                }
+
+                R.id.tomorrow_screen -> {
+                    // Reset selected date to tomorrow
+                    val tomorrow = OffsetDateTime.now().plusDays(1)
+                    Data.saveDate(tomorrow)
+
+                    if (!navController.popBackStack(R.id.tomorrow_screen, false)) {
+                        it.onNavDestinationSelected(navController)
+                    }
                     true
                 }
 

--- a/app/src/main/java/co/develhope/meteoapp/today/TodayScreenFragment.kt
+++ b/app/src/main/java/co/develhope/meteoapp/today/TodayScreenFragment.kt
@@ -86,11 +86,15 @@ class TodayScreenFragment : Fragment() {
 
     private fun DailyDataLocal?.toHourlyForecastItems(): List<HourlyForecastItems> {
 
+        val filteredList = this?.filter {
+            it.time.isEqual(OffsetDateTime.now()) || it.time.isAfter(OffsetDateTime.now())
+        }
+
         val newList = mutableListOf<HourlyForecastItems>()
 
         newList.add(HourlyForecastItems.Title(Data.getCityLocation(), OffsetDateTime.now()))
 
-        this?.forEach { hourly ->
+        filteredList?.forEach { hourly ->
             newList.add(
                 HourlyForecastItems.Forecast(
                     HourlyForecast(


### PR DESCRIPTION
Today screen now shows weather based on the user's current hour, instead of starting from midnight.
Tomorrow screen's date is now able to reset by clicking another icon and then clicking the tomorrow icon again.